### PR TITLE
Integrate clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+# vi: ft=yaml
+BasedOnStyle: Google
+IndentWidth: 4
+NamespaceIndentation: All
+Standard: Cpp11

--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,5 @@ BasedOnStyle: Google
 IndentWidth: 4
 ColumnLimit: 120
 NamespaceIndentation: All
+FixNamespaceComments: false
 Standard: Cpp11

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 # vi: ft=yaml
 BasedOnStyle: Google
 IndentWidth: 4
+ColumnLimit: 120
 NamespaceIndentation: All
 Standard: Cpp11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.2")
 endif()
 
 # Include custom cmake modules
+include(cmake/ClangFormat.cmake)
 include(cmake/GetGitRevisionDescription.cmake)
 include(cmake/HealthCheck.cmake)
 include(cmake/GenerateTemplateExportHeader.cmake)
@@ -114,6 +115,13 @@ add_check_template_target(${META_CMAKE_INIT_SHA})
 # Configure health check tools
 enable_cppcheck(On)
 enable_clang_tidy(On)
+
+
+#
+# Source Code Formatting Setup
+#
+
+enable_clang_format(On)
 
 
 #

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,59 @@
+
+set(OPTION_CLANG_FORMAT_ENABLED Off)
+
+# Function to register a target for formatting (if enabled)
+function(add_clang_format_target target)
+    if(NOT OPTION_CLANG_FORMAT_ENABLED)
+        return()
+    endif()
+
+    if(NOT TARGET format-all)
+        add_custom_target(format-all)
+
+        set_target_properties(format-all
+            PROPERTIES
+            FOLDER "Maintenance"
+            EXCLUDE_FROM_DEFAULT_BUILD 1
+        )
+    endif()
+
+    add_custom_target(
+        format-${target}
+        COMMAND
+            ${clang_format_EXECUTABLE}
+                -i
+                -style=file
+                ${ARGN}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    set_target_properties(format-${target}
+        PROPERTIES
+        FOLDER "Maintenance"
+        EXCLUDE_FROM_DEFAULT_BUILD 1
+    )
+
+    add_dependencies(format-all format-${target})
+endfunction()
+
+# Enable or disable clang-format
+function(enable_clang_format status)
+    if(NOT ${status})
+        set(OPTION_CLANG_FORMAT_ENABLED ${status} PARENT_SCOPE)
+        message(STATUS "Clang-format skipped: Manually disabled")
+
+        return()
+    endif()
+
+    find_package(clang_format)
+
+    if(NOT clang_format_FOUND)
+        set(OPTION_CLANG_TIDY_ENABLED Off PARENT_SCOPE)
+        message(STATUS "Clang-format skipped: Not found")
+
+        return()
+    endif()
+
+    set(OPTION_CLANG_FORMAT_ENABLED ${status} PARENT_SCOPE)
+    message(STATUS "Clang-format enabled")
+endfunction()

--- a/cmake/Findclang_format.cmake
+++ b/cmake/Findclang_format.cmake
@@ -1,0 +1,22 @@
+
+# Findclang_format results:
+# clang_format_FOUND
+# clang_format_EXECUTABLE
+
+include(FindPackageHandleStandardArgs)
+
+find_program(clang_format_EXECUTABLE
+    NAMES
+        clang-format
+    PATHS
+        "${CLANG_FORMAT_DIR}"
+)
+
+find_package_handle_standard_args(clang_format
+    FOUND_VAR
+        clang_format_FOUND
+    REQUIRED_VARS
+        clang_format_EXECUTABLE
+)
+
+mark_as_advanced(clang_format_EXECUTABLE)

--- a/source/llassetgen-cmd/CMakeLists.txt
+++ b/source/llassetgen-cmd/CMakeLists.txt
@@ -113,6 +113,13 @@ perform_health_checks(
 
 
 #
+# Source Code Formatting
+#
+
+add_clang_format_target(${target} ${sources} ${headers})
+
+
+#
 # Deployment
 #
 

--- a/source/llassetgen-cmd/main.cpp
+++ b/source/llassetgen-cmd/main.cpp
@@ -5,15 +5,13 @@
 
 #include <llassetgen/llassetgen.h>
 
-
-
 using namespace llassetgen;
 
 int main(int argc, char** argv) {
     llassetgen::init();
 
     std::unique_ptr<DistanceTransform> dt(new DeadReckoning());
-    if(argc == 5 && strcmp(argv[1], "-dt-from-glyph") == 0) {
+    if (argc == 5 && strcmp(argv[1], "-dt-from-glyph") == 0) {
         // Example: llassetgen-cmd -dt-from-glyph G /Library/Fonts/Verdana.ttf glyph.png
         FT_Face face;
         assert(FT_New_Face(freetype, argv[3], 0, &face) == 0);
@@ -22,7 +20,7 @@ int main(int argc, char** argv) {
         dt->importFreeTypeBitmap(&face->glyph->bitmap, 20);
         dt->transform();
         dt->exportPng(argv[4], -10, 20, 8);
-    } else if(argc == 4 && strcmp(argv[1], "-dt-from-png") == 0) {
+    } else if (argc == 4 && strcmp(argv[1], "-dt-from-png") == 0) {
         // Example: llassetgen-cmd -dt-from-png input.png output.png
         dt->importPng(argv[2]);
         dt->transform();

--- a/source/llassetgen/CMakeLists.txt
+++ b/source/llassetgen/CMakeLists.txt
@@ -205,6 +205,13 @@ perform_health_checks(
 
 
 #
+# Source Code Formatting
+#
+
+add_clang_format_target(${target} ${sources} ${headers})
+
+
+#
 # Deployment
 #
 

--- a/source/llassetgen/include/llassetgen/DistanceTransform.h
+++ b/source/llassetgen/include/llassetgen/DistanceTransform.h
@@ -1,35 +1,32 @@
 #pragma once
 
-#include <llassetgen/llassetgen_api.h>
-#include <llassetgen/llassetgen.h>
 #include <llassetgen/Vec2.h>
+#include <llassetgen/llassetgen.h>
+#include <llassetgen/llassetgen_api.h>
 
 struct FT_Bitmap_;
 struct png_struct_def;
 
 namespace llassetgen {
     class DistanceTransform {
-        public:
+       public:
         using DimensionType = int;
         using InputType = unsigned char;
         using OutputType = float;
         using PositionType = Vec2<DimensionType>;
 
-        protected:
+       protected:
         std::unique_ptr<InputType[]> input;
         std::unique_ptr<OutputType[]> output;
-        template<typename PixelType>
+        template <typename PixelType>
         void exportPngInternal(png_struct_def*, OutputType, OutputType);
 
-        public:
+       public:
         DimensionType width, height;
 
-        DistanceTransform()
-            :width(0), height(0) {}
+        DistanceTransform() : width(0), height(0) {}
 
-        DistanceTransform(DimensionType _width, DimensionType _height) {
-            resetInput(_width, _height, true);
-        }
+        DistanceTransform(DimensionType _width, DimensionType _height) { resetInput(_width, _height, true); }
 
         void resetInput(DimensionType width, DimensionType height, bool clear);
         bool inputAt(DimensionType offset);
@@ -42,7 +39,8 @@ namespace llassetgen {
 
         LLASSETGEN_API void importFreeTypeBitmap(FT_Bitmap_* bitmap, DimensionType padding);
         LLASSETGEN_API void importPng(std::string path);
-        LLASSETGEN_API void exportPng(std::string path, OutputType blackDistance, OutputType whiteDistance, DimensionType bitDepth);
+        LLASSETGEN_API void exportPng(std::string path, OutputType blackDistance, OutputType whiteDistance,
+                                      DimensionType bitDepth);
 
         virtual void transform() = 0;
     };
@@ -53,7 +51,7 @@ namespace llassetgen {
         PositionType& posAt(PositionType pos);
         void transformAt(PositionType pos, PositionType target, OutputType distance);
 
-        public:
+       public:
         LLASSETGEN_API void transform();
     };
 
@@ -67,7 +65,7 @@ namespace llassetgen {
 
         void transformLine(DimensionType offset, DimensionType pitch, DimensionType length);
 
-        public:
+       public:
         void transform();
     };
 }

--- a/source/llassetgen/include/llassetgen/llassetgen.h
+++ b/source/llassetgen/include/llassetgen/llassetgen.h
@@ -9,8 +9,6 @@
 
 #include <llassetgen/llassetgen_api.h>
 
-
-
 struct FT_LibraryRec_;
 
 namespace llassetgen {

--- a/source/llassetgen/source/DistanceTransform.cpp
+++ b/source/llassetgen/source/DistanceTransform.cpp
@@ -1,20 +1,30 @@
 #include <algorithm>
 #include <limits>
 
+/*
+ * If we sort png.h below the freetype includes, an compile error will be
+ * generated warning about multiple includes of setjmp (on some version of
+ * libpng). Because we don't use the setjmp functionality of freetype, this is
+ * not applicable in this case. Unfortunately, the compile error can only be
+ * fixed by editing png.h or reordering the includes.
+ *
+ * See https://sourceforge.net/p/enlightenment/mailman/message/12595025/ for
+ * some discussion on this topic.
+ */
+// clang-format off
 #include <png.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
+// clang-format on
 
 #include <llassetgen/DistanceTransform.h>
 
-
-
-template<typename T>
+template <typename T>
 T square(T value) {
     return value * value;
 }
 
-template<typename T>
+template <typename T>
 T clamp(T val, T min, T max) {
     return std::max(min, std::min(max, val));
 }
@@ -26,32 +36,30 @@ namespace llassetgen {
         height = _height;
         DimensionType size = (width * height + 7) / 8;
         input.reset(new InputType[size]);
-        if(clear)
-            memset(input.get(), 0, size);
+        if (clear) memset(input.get(), 0, size);
     }
 
     bool DistanceTransform::inputAt(DimensionType offset) {
         assert(offset < width * height && input.get());
-        return (input[offset/8] >> (offset%8)) & 1;
+        return (input[offset / 8] >> (offset % 8)) & 1;
     }
 
     bool DistanceTransform::inputAt(PositionType pos) {
         assert(pos.x < width && pos.y < height);
-        return inputAt(pos.y*width+pos.x);
+        return inputAt(pos.y * width + pos.x);
     }
 
     bool DistanceTransform::inputAtClamped(PositionType pos) {
-        if(static_cast<int>(pos.x) < 0 || static_cast<int>(pos.y) < 0 || pos.x >= width || pos.y >= height)
-            return 0;
+        if (static_cast<int>(pos.x) < 0 || static_cast<int>(pos.y) < 0 || pos.x >= width || pos.y >= height) return 0;
         return inputAt(pos);
     }
 
     void DistanceTransform::inputAt(PositionType pos, bool bit) {
         assert(pos.x < width && pos.y < height && input.get());
-        DimensionType i = pos.y*width+pos.x;
-        InputType mask = 1 << (i%8);
+        DimensionType i = pos.y * width + pos.x;
+        InputType mask = 1 << (i % 8);
         i /= 8;
-        if(bit)
+        if (bit)
             input[i] |= mask;
         else
             input[i] &= ~mask;
@@ -64,22 +72,22 @@ namespace llassetgen {
 
     DistanceTransform::OutputType& DistanceTransform::outputAt(PositionType pos) {
         assert(pos.x < width && pos.y < height && output.get());
-        return output[pos.y*width+pos.x];
+        return output[pos.y * width + pos.x];
     }
 
     DistanceTransform::OutputType DistanceTransform::outputAtClamped(PositionType pos) {
         assert(output.get());
-        if(static_cast<int>(pos.x) < 0 || static_cast<int>(pos.y) < 0 || pos.x >= width || pos.y >= height)
+        if (static_cast<int>(pos.x) < 0 || static_cast<int>(pos.y) < 0 || pos.x >= width || pos.y >= height)
             return std::numeric_limits<OutputType>::infinity();
-        return output[pos.y*width+pos.x];
+        return output[pos.y * width + pos.x];
     }
 
     void DistanceTransform::importFreeTypeBitmap(FT_Bitmap* bitmap, DimensionType padding) {
         assert(bitmap);
-        resetInput(bitmap->width + padding*2, bitmap->rows + padding*2, true);
-        for(DimensionType y = 0; y < static_cast<int>(bitmap->rows); ++y)
-            for(DimensionType x = 0; x < static_cast<int>(bitmap->width); ++x)
-                inputAt({padding+x, padding+y}, (bitmap->buffer[y*bitmap->pitch+(x/8)] >> (7-x%8)) & 1);
+        resetInput(bitmap->width + padding * 2, bitmap->rows + padding * 2, true);
+        for (DimensionType y = 0; y < static_cast<int>(bitmap->rows); ++y)
+            for (DimensionType x = 0; x < static_cast<int>(bitmap->width); ++x)
+                inputAt({padding + x, padding + y}, (bitmap->buffer[y * bitmap->pitch + (x / 8)] >> (7 - x % 8)) & 1);
     }
 
     void DistanceTransform::importPng(std::string path) {
@@ -88,30 +96,29 @@ namespace llassetgen {
         int bitDepth = 0, colorType = 0;
         png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
         png_infop pngInfo = png_create_info_struct(png);
-        if(setjmp(png_jmpbuf(png)))
+        if (setjmp(png_jmpbuf(png)))
             assert(false);
         else {
             png_init_io(png, file);
             png_read_info(png, pngInfo);
             png_set_strip_16(png);
-            if(colorType == PNG_COLOR_TYPE_PALETTE)
-                png_set_palette_to_rgb(png);
-            if(colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8)
-                png_set_expand_gray_1_2_4_to_8(png);
+            if (colorType == PNG_COLOR_TYPE_PALETTE) png_set_palette_to_rgb(png);
+            if (colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8) png_set_expand_gray_1_2_4_to_8(png);
             assert(png_set_interlace_handling(png) == 1);
             png_read_update_info(png, pngInfo);
-            png_get_IHDR(png, pngInfo, reinterpret_cast<png_uint_32*>(&width), reinterpret_cast<png_uint_32*>(&height), &bitDepth, &colorType, nullptr, nullptr, nullptr);
+            png_get_IHDR(png, pngInfo, reinterpret_cast<png_uint_32*>(&width), reinterpret_cast<png_uint_32*>(&height),
+                         &bitDepth, &colorType, nullptr, nullptr, nullptr);
             assert(colorType == PNG_COLOR_TYPE_GRAY);
             assert(bitDepth == 8);
             DimensionType index = 0;
             InputType byte = 0, bit = 0;
             resetInput(width, height, false);
             std::unique_ptr<InputType[]> rowBuffer(new InputType[width]);
-            for(DimensionType y = 0; y < height; ++y) {
+            for (DimensionType y = 0; y < height; ++y) {
                 png_read_row(png, reinterpret_cast<png_bytep>(rowBuffer.get()), nullptr);
-                for(DimensionType x = 0; x < width; ++x) {
-                    byte |= (rowBuffer[x] >= std::numeric_limits<InputType>::max()/2 ? 1 : 0) << bit;
-                    if(++bit >= 8) {
+                for (DimensionType x = 0; x < width; ++x) {
+                    byte |= (rowBuffer[x] >= std::numeric_limits<InputType>::max() / 2 ? 1 : 0) << bit;
+                    if (++bit >= 8) {
                         input[index++] = byte;
                         byte = bit = 0;
                     }
@@ -123,32 +130,33 @@ namespace llassetgen {
         fclose(file);
     }
 
-    template<typename PixelType>
+    template <typename PixelType>
     void DistanceTransform::exportPngInternal(png_struct* png, OutputType blackDistance, OutputType whiteDistance) {
         std::unique_ptr<PixelType[]> rowBuffer(new PixelType[width]);
-        for(DimensionType y = 0; y < height; ++y) {
-            for(DimensionType x = 0; x < width; ++x)
-                rowBuffer[x] = clamp((outputAt({x, y})-blackDistance) / (whiteDistance-blackDistance), 0.0F, 1.0F) * std::numeric_limits<PixelType>::max();
+        for (DimensionType y = 0; y < height; ++y) {
+            for (DimensionType x = 0; x < width; ++x)
+                rowBuffer[x] = clamp((outputAt({x, y}) - blackDistance) / (whiteDistance - blackDistance), 0.0F, 1.0F) *
+                               std::numeric_limits<PixelType>::max();
             png_write_row(png, reinterpret_cast<png_bytep>(rowBuffer.get()));
         }
     }
 
-    void DistanceTransform::exportPng(std::string path, OutputType blackDistance, OutputType whiteDistance, DimensionType bitDepth) {
+    void DistanceTransform::exportPng(std::string path, OutputType blackDistance, OutputType whiteDistance,
+                                      DimensionType bitDepth) {
         assert(width > 0 && height > 0 && output.get());
         FILE* file = fopen(path.c_str(), "w");
         assert(file);
         png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
         png_infop pngInfo = png_create_info_struct(png);
-        if(setjmp(png_jmpbuf(png)))
+        if (setjmp(png_jmpbuf(png)))
             assert(false);
         else {
             png_init_io(png, file);
-            png_set_IHDR(png, pngInfo, width, height,
-                         bitDepth, PNG_COLOR_TYPE_GRAY, PNG_INTERLACE_NONE,
+            png_set_IHDR(png, pngInfo, width, height, bitDepth, PNG_COLOR_TYPE_GRAY, PNG_INTERLACE_NONE,
                          PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
             png_write_info(png, pngInfo);
             png_set_swap(png);
-            switch(bitDepth) {
+            switch (bitDepth) {
                 case 8:
                     exportPngInternal<unsigned char>(png, blackDistance, whiteDistance);
                     break;
@@ -164,18 +172,16 @@ namespace llassetgen {
         fclose(file);
     }
 
-
-
     DeadReckoning::PositionType& DeadReckoning::posAt(PositionType pos) {
         assert(pos.x < width && pos.y < height && posBuffer.get());
-        return posBuffer[pos.y*width+pos.x];
+        return posBuffer[pos.y * width + pos.x];
     }
 
     void DeadReckoning::transformAt(PositionType pos, PositionType target, OutputType distance) {
         target += pos;
-        if(outputAtClamped(target)+distance < outputAt(pos)) {
+        if (outputAtClamped(target) + distance < outputAt(pos)) {
             posAt(pos) = target = posAt(target);
-            outputAt(pos) = std::sqrt(square(pos.x-target.x)+square(pos.y-target.y));
+            outputAt(pos) = std::sqrt(square(pos.x - target.x) + square(pos.y - target.y));
         }
     }
 
@@ -184,63 +190,58 @@ namespace llassetgen {
         output.reset(new OutputType[width * height]);
         posBuffer.reset(new PositionType[width * height]);
 
-        for(DimensionType y = 0; y < height; ++y)
-            for(DimensionType x = 0; x < width; ++x) {
+        for (DimensionType y = 0; y < height; ++y)
+            for (DimensionType x = 0; x < width; ++x) {
                 PositionType pos = {x, y};
                 bool center = inputAt(pos);
                 posAt(pos) = pos;
-                outputAt(pos) = (center && (
-                                 inputAtClamped({x-1, y}) != center || inputAtClamped({x+1, y}) != center ||
-                                 inputAtClamped({x, y-1}) != center || inputAtClamped({x, y+1}) != center))
-                                ? 0 : std::numeric_limits<OutputType>::infinity();
+                outputAt(pos) =
+                    (center && (inputAtClamped({x - 1, y}) != center || inputAtClamped({x + 1, y}) != center ||
+                                inputAtClamped({x, y - 1}) != center || inputAtClamped({x, y + 1}) != center))
+                        ? 0
+                        : std::numeric_limits<OutputType>::infinity();
             }
 
-        const OutputType distance[] = {
-            std::sqrt(2.0F), 1.0F, std::sqrt(2.0F), 1.0F
-        };
-        const PositionType target[] = {
-            {-1, -1}, { 0, -1}, {+1, -1}, {-1,  0}
-        };
+        const OutputType distance[] = {std::sqrt(2.0F), 1.0F, std::sqrt(2.0F), 1.0F};
+        const PositionType target[] = {{-1, -1}, {0, -1}, {+1, -1}, {-1, 0}};
 
-        for(DimensionType y = 0; y < height; ++y)
-            for(DimensionType x = 0; x < width; ++x)
-                for(DimensionType i = 0; i < 4; ++i)
-                    transformAt({x, y}, target[i], distance[i]);
+        for (DimensionType y = 0; y < height; ++y)
+            for (DimensionType x = 0; x < width; ++x)
+                for (DimensionType i = 0; i < 4; ++i) transformAt({x, y}, target[i], distance[i]);
 
-        for(DimensionType y = 0; y < height; ++y)
-            for(DimensionType x = 0; x < width; ++x)
-                for(DimensionType i = 0; i < 4; ++i)
-                    transformAt({width-x-1, height-y-1}, -(target[3-i]), distance[3-i]);
+        for (DimensionType y = 0; y < height; ++y)
+            for (DimensionType x = 0; x < width; ++x)
+                for (DimensionType i = 0; i < 4; ++i)
+                    transformAt({width - x - 1, height - y - 1}, -(target[3 - i]), distance[3 - i]);
 
-        for(DimensionType y = 0; y < height; ++y)
-            for(DimensionType x = 0; x < width; ++x)
-                if(inputAt({x, y}))
-                    outputAt({x, y}) *= -1;
+        for (DimensionType y = 0; y < height; ++y)
+            for (DimensionType x = 0; x < width; ++x)
+                if (inputAt({x, y})) outputAt({x, y}) *= -1;
     }
-
-
 
     void ParabolaEnvelope::transformLine(DimensionType offset, DimensionType pitch, DimensionType length) {
         parabolas[0].apex = 0;
         parabolas[0].begin = -std::numeric_limits<OutputType>::infinity();
-        parabolas[0].value = outputAt(offset+0*pitch);
+        parabolas[0].value = outputAt(offset + 0 * pitch);
         parabolas[1].begin = +std::numeric_limits<OutputType>::infinity();
-        for(DimensionType parabola = 0, i = 1; i < length; ++i) {
+        for (DimensionType parabola = 0, i = 1; i < length; ++i) {
             OutputType begin;
             do {
                 DimensionType apex = parabolas[parabola].apex;
-                begin = (outputAt(offset+i*pitch)+square(i) - (parabolas[parabola].value+square(apex))) / (2 * (i - apex));
-            } while(begin <= parabolas[parabola--].begin);
+                begin = (outputAt(offset + i * pitch) + square(i) - (parabolas[parabola].value + square(apex))) /
+                        (2 * (i - apex));
+            } while (begin <= parabolas[parabola--].begin);
             parabola += 2;
             parabolas[parabola].apex = i;
             parabolas[parabola].begin = begin;
-            parabolas[parabola].value = outputAt(offset+i*pitch);
-            parabolas[parabola+1].begin = std::numeric_limits<OutputType>::infinity();
+            parabolas[parabola].value = outputAt(offset + i * pitch);
+            parabolas[parabola + 1].begin = std::numeric_limits<OutputType>::infinity();
         }
-        for(DimensionType parabola = 0, i = 0; i < length; ++i) {
-            while(parabolas[++parabola].begin < i);
+        for (DimensionType parabola = 0, i = 0; i < length; ++i) {
+            while (parabolas[++parabola].begin < i)
+                ;
             --parabola;
-            outputAt(offset+i*pitch) = parabolas[parabola].value+square(i-parabolas[parabola].apex);
+            outputAt(offset + i * pitch) = parabolas[parabola].value + square(i - parabolas[parabola].apex);
         }
     }
 
@@ -248,21 +249,17 @@ namespace llassetgen {
         assert(width > 0 && height > 0);
         output.reset(new OutputType[width * height]);
         DimensionType length = std::max(width, height);
-        parabolas.reset(new Parabola[length+1]);
+        parabolas.reset(new Parabola[length + 1]);
         lineBuffer.reset(new OutputType[length]);
 
-        for(DimensionType y = 0; y < height; ++y)
-            for(DimensionType x = 0; x < width; ++x)
-                outputAt({x, y}) = (inputAt({x, y})) ? 0 : 1E20;
+        for (DimensionType y = 0; y < height; ++y)
+            for (DimensionType x = 0; x < width; ++x) outputAt({x, y}) = (inputAt({x, y})) ? 0 : 1E20;
 
-        for(DimensionType y = 0; y < height; ++y)
-            transformLine(y*width, 1, width);
+        for (DimensionType y = 0; y < height; ++y) transformLine(y * width, 1, width);
 
-        for(DimensionType x = 0; x < width; ++x)
-            transformLine(x, width, height);
+        for (DimensionType x = 0; x < width; ++x) transformLine(x, width, height);
 
-        for(DimensionType x = 0; x < width; ++x)
-            for(DimensionType y = 0; y < height; ++y)
-                outputAt({x, y}) = std::sqrt(outputAt({x, y}));
+        for (DimensionType x = 0; x < width; ++x)
+            for (DimensionType y = 0; y < height; ++y) outputAt({x, y}) = std::sqrt(outputAt({x, y}));
     }
 }

--- a/source/llassetgen/source/llassetgen.cpp
+++ b/source/llassetgen/source/llassetgen.cpp
@@ -3,12 +3,8 @@
 
 #include <llassetgen/llassetgen.h>
 
-
-
 namespace llassetgen {
     FT_Library freetype;
 
-    void init() {
-        assert(FT_Init_FreeType(&freetype) == 0);
-    }
+    void init() { assert(FT_Init_FreeType(&freetype) == 0); }
 }


### PR DESCRIPTION
Adds CMake targets to run clang-format and a `.clang-tidy` file to control the formatting. The CMake code is adapted from the health checks code, there is `format-${target}` target for each library/executable, and a `format-all` target for convenience.

The settings are open for discussion, I simply copied from a previous project of mine. [See here](https://github.com/hpicgs/openll-asset-generator/compare/integrate-clang-format...clang-format-example) for what the current code formatted with the current settings would look like. The current settings are based on the google style guide, run `clang-format -style=file -dump-config` to see the full list of configured settings.

Note to self: Delete `clang-format-example` branch when this gets merged.