### PR TITLE
Configure clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,8 @@
 ---
-Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast,-llvm-header-guard,-google-readability-namespace-comments'
+# android-*: Not applicable
+# cppcoreguidelines-pro-bounds-constant-array-index: Causes false positives when using assert
+#
+# All others are code style differences
+Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast,-llvm-header-guard,-google-readability-namespace-comments,-cppcoreguidelines-pro-bounds-array-to-pointer-decay'
 HeaderFilterRegex: '.*'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: '*'
+Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast'
 HeaderFilterRegex: '.*'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast'
+Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast,-llvm-header-guard,-google-readability-namespace-comments'
 HeaderFilterRegex: '.*'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: '*'
+HeaderFilterRegex: '.*'
+...

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -9,7 +9,8 @@ function(perform_clang_tidy check_target target)
             ${clang_tidy_EXECUTABLE}
                 -p\t${PROJECT_BINARY_DIR}
                 ${ARGN}
-                -checks=*
+                # Instructs clang-tidy to load a .clang-tidy config file
+                -config=
                 "$<$<NOT:$<BOOL:${CMAKE_EXPORT_COMPILE_COMMANDS}>>:--\t$<$<BOOL:${includes}>:-I$<JOIN:${includes},\t-I>>>"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )

--- a/source/llassetgen-cmd/main.cpp
+++ b/source/llassetgen-cmd/main.cpp
@@ -1,20 +1,19 @@
 #include <iostream>
 
-#include <ft2build.h>
+#include <ft2build.h> // NOLINT include order required by freetype
 #include FT_FREETYPE_H
 
 #include <llassetgen/llassetgen.h>
 
-using namespace llassetgen;
 
 int main(int argc, char** argv) {
     llassetgen::init();
 
-    std::unique_ptr<DistanceTransform> dt(new DeadReckoning());
-    if (argc == 5 && strcmp(argv[1], "-dt-from-glyph") == 0) {
+    std::unique_ptr<llassetgen::DistanceTransform> dt(new llassetgen::DeadReckoning());
+    if(argc == 5 && strcmp(argv[1], "-dt-from-glyph") == 0) {
         // Example: llassetgen-cmd -dt-from-glyph G /Library/Fonts/Verdana.ttf glyph.png
         FT_Face face;
-        assert(FT_New_Face(freetype, argv[3], 0, &face) == 0);
+        assert(FT_New_Face(llassetgen::freetype, argv[3], 0, &face) == 0);
         assert(FT_Set_Pixel_Sizes(face, 0, 128) == 0);
         assert(FT_Load_Glyph(face, FT_Get_Char_Index(face, argv[2][0]), FT_LOAD_RENDER | FT_LOAD_TARGET_MONO) == 0);
         dt->importFreeTypeBitmap(&face->glyph->bitmap, 20);

--- a/source/llassetgen/include/llassetgen/llassetgen.h
+++ b/source/llassetgen/include/llassetgen/llassetgen.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 #include <cmath>
 #include <memory>
 #include <string>

--- a/source/llassetgen/source/DistanceTransform.cpp
+++ b/source/llassetgen/source/DistanceTransform.cpp
@@ -12,7 +12,7 @@
  * some discussion on this topic.
  */
 // clang-format off
-#include <png.h>
+#include <png.h> // NOLINT
 #include <ft2build.h>
 #include FT_FREETYPE_H
 // clang-format on

--- a/source/llassetgen/source/llassetgen.cpp
+++ b/source/llassetgen/source/llassetgen.cpp
@@ -1,4 +1,4 @@
-#include <ft2build.h>
+#include <ft2build.h> // NOLINT include order required by freetype
 #include FT_FREETYPE_H
 
 #include <llassetgen/llassetgen.h>


### PR DESCRIPTION
Configures clang tidy to check header files and disables some unnecessary lints (compare #20). Also includes some fixes for easy-to-fix warnings.