### PR TITLE
fix broken appveyor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Font Asset Generator based on OpenLL Specifications
 | Service | System | Compiler | Status |
 | :------ | ------ | -------- | -----: |
 | [Travis-CI](https://travis-ci.org/hpicgs/openll-asset-generator) | Ubuntu 14.04, macOS | GCC 4.8, Clang 3.9 <br> AppleClang 8.1 | [![Travis Build Status](https://img.shields.io/travis/hpicgs/openll-asset-generator.svg)]()|
-| [AppVeyor](https://ci.appveyor.com/project/anne-gropler/openll-asset-generator) | Windows | MSVC 2015<br>MSVC 2017 | [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/anne-gropler/openll-asset-generator-5cjbt.svg)]()|
+| [AppVeyor](https://ci.appveyor.com/project/anne-gropler/openll-asset-generator-5cjbt) | Windows | MSVC 2015<br>MSVC 2017 | [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/anne-gropler/openll-asset-generator-5cjbt.svg)]()|

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Font Asset Generator based on OpenLL Specifications
 
 | Service | System | Compiler | Status |
 | :------ | ------ | -------- | -----: |
-|  [Travis-CI](https://travis-ci.org/hpicgs/openll-asset-generator) | Ubuntu 14.04, macOS | GCC 4.8, Clang 3.9 <br> AppleClang 8.1 | [![Travis Build Status](https://img.shields.io/travis/hpicgs/openll-asset-generator.svg)]()|
-| [AppVeyor](https://ci.appveyor.com/project/anne-gropler/openll-asset-generator) | Windows | MSVC 2015<br>MSVC 2017 | [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/anne-gropler/openll-asset-generator/master.svg)]()|
+| [Travis-CI](https://travis-ci.org/hpicgs/openll-asset-generator) | Ubuntu 14.04, macOS | GCC 4.8, Clang 3.9 <br> AppleClang 8.1 | [![Travis Build Status](https://img.shields.io/travis/hpicgs/openll-asset-generator.svg)]()|
+| [AppVeyor](https://ci.appveyor.com/project/anne-gropler/openll-asset-generator) | Windows | MSVC 2015<br>MSVC 2017 | [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/anne-gropler/openll-asset-generator-5cjbt.svg)]()|


### PR DESCRIPTION
Since that we now build all branches on appveyor, the link apparently changed. Please make sure that you see the appveyor badge "passing" or "failing", but NOT "project not found or access denied".