### PR TITLE
Optimize fast packing method

### DIFF
--- a/source/llassetgen/include/llassetgen/Packing.h
+++ b/source/llassetgen/include/llassetgen/Packing.h
@@ -92,6 +92,7 @@ namespace llassetgen {
             LLASSETGEN_NO_EXPORT bool packNextNoRotations(Vec2<PackingSizeType> rectSize);
             LLASSETGEN_NO_EXPORT bool packNextWithRotations(Vec2<PackingSizeType> rectSize);
             LLASSETGEN_NO_EXPORT void openNewShelf();
+            LLASSETGEN_NO_EXPORT bool storeMaybeGrow(Vec2<PackingSizeType> rectSize);
             LLASSETGEN_NO_EXPORT void store(Vec2<PackingSizeType> rectSize);
 
             Packing& packing;

--- a/source/llassetgen/source/Packing.cpp
+++ b/source/llassetgen/source/Packing.cpp
@@ -25,18 +25,7 @@ namespace llassetgen {
                 }
             }
 
-            if (usedHeight + rectSize.y > packing.atlasSize.y) {
-                if (allowGrowth) {
-                    PackingSizeType finalHeight = usedHeight + rectSize.y;
-                    auto numDoublings = ceilLog2(ceilDiv(finalHeight, packing.atlasSize.y));
-                    packing.atlasSize.y <<= numDoublings;
-                } else {
-                    return false;
-                }
-            }
-
-            store(rectSize);
-            return true;
+            return storeMaybeGrow(rectSize);
         }
 
         bool ShelfNextFitPacker::packNextWithRotations(Vec2<PackingSizeType> rectSize) {
@@ -51,8 +40,8 @@ namespace llassetgen {
                 store({maxSide, minSide});
             } else {
                 openNewShelf();
-                return maxSide > packing.atlasSize.x ? packNextNoRotations({minSide, maxSide})
-                                                     : packNextNoRotations({maxSide, minSide});
+                return maxSide > packing.atlasSize.x ? storeMaybeGrow({minSide, maxSide})
+                                                     : storeMaybeGrow({maxSide, minSide});
             }
 
             return true;
@@ -61,6 +50,21 @@ namespace llassetgen {
         void ShelfNextFitPacker::openNewShelf() {
             usedHeight += currentShelfSize.y;
             currentShelfSize = {0, 0};
+        }
+
+        bool ShelfNextFitPacker::storeMaybeGrow(Vec2<PackingSizeType> rectSize) {
+            if (usedHeight + rectSize.y > packing.atlasSize.y) {
+                if (allowGrowth) {
+                    PackingSizeType finalHeight = usedHeight + rectSize.y;
+                    auto numDoublings = ceilLog2(ceilDiv(finalHeight, packing.atlasSize.y));
+                    packing.atlasSize.y <<= numDoublings;
+                } else {
+                    return false;
+                }
+            }
+
+            store(rectSize);
+            return true;
         }
 
         void ShelfNextFitPacker::store(Vec2<PackingSizeType> rectSize) {

--- a/source/llassetgen/source/Packing.cpp
+++ b/source/llassetgen/source/Packing.cpp
@@ -5,8 +5,8 @@
 
 using llassetgen::PackingSizeType;
 
-PackingSizeType ceilDiv(PackingSizeType divident, PackingSizeType divisor) {
-    return (divident + divisor - 1) / divisor;
+PackingSizeType ceilDiv(PackingSizeType dividend, PackingSizeType divisor) {
+    return (dividend + divisor - 1) / divisor;
 }
 
 namespace llassetgen {


### PR DESCRIPTION
Avoids throwing away partial results when the guessed atlas size is too small.

Downside: Texture atlases might be less square (only height gets increased after initial guess). Should only matter if initial guess for the size is more than 2x off, i.e. the resulting packing has less than 50% space efficiency.