### PR TITLE
Miscellaneous clang-tidy/cppcheck fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,13 @@
 # cppcoreguidelines-pro-bounds-constant-array-index: Causes false positives when using assert
 #
 # All others are code style differences
-Checks: '*,-android-*,-llvm-namespace-comment,-readability-implicit-bool-cast,-llvm-header-guard,-google-readability-namespace-comments,-cppcoreguidelines-pro-bounds-array-to-pointer-decay'
+Checks: "*,\
+         -android-*,\
+         -llvm-namespace-comment,\
+         -readability-implicit-bool-cast,\
+         -llvm-header-guard,\
+         -google-readability-namespace-comments,\
+         -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
+         -google-runtime-references"
 HeaderFilterRegex: '.*'
 ...

--- a/cmake/Cppcheck.cmake
+++ b/cmake/Cppcheck.cmake
@@ -14,6 +14,7 @@ function(perform_cppcheck check_target target)
                 --std=c++11
                 --verbose
                 --suppress=missingIncludeSystem
+                --suppress=preprocessorErrorDirective
                 ${ARGN}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )

--- a/source/llassetgen/include/llassetgen/llassetgen.h
+++ b/source/llassetgen/include/llassetgen/llassetgen.h
@@ -16,4 +16,4 @@ namespace llassetgen {
     LLASSETGEN_API extern FT_LibraryRec_* freetype;
 
     LLASSETGEN_API void init();
-};
+}


### PR DESCRIPTION
Some clang-tidy/cppcheck tweaks and fixes that accumulated over time and didn't belong into any other PR.