### PR TITLE
Disable adaptive pointer formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ ColumnLimit: 120
 NamespaceIndentation: All
 FixNamespaceComments: false
 Standard: Cpp11
+DerivePointerAlignment: false


### PR DESCRIPTION
clang-format derives pointer formatting (`type* name` vs. `type *name`) from the unformatted source file by default. This turns this off in favor of `type* name`.