### PR TITLE
Disable unnecessary clang-tidy 6 checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,8 @@ Checks: "*,\
          -llvm-header-guard,\
          -google-readability-namespace-comments,\
          -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
-         -google-runtime-references"
+         -google-runtime-references,\
+         -fuchsia-overloaded-operator,\
+         -fuchsia-default-arguments"
 HeaderFilterRegex: '.*'
 ...


### PR DESCRIPTION
Clang-tidy 6.0 adds new checks based on the guidelines for googles fuchsia OS. This disables the ones disallowing operator overloads and function calls using default parameters (there might be more unnecessary ones, but these turned up with the current code).