### PR TITLE
Necessary changes for homebrew formula

### DIFF
--- a/source/llassetgen-cmd/CMakeLists.txt
+++ b/source/llassetgen-cmd/CMakeLists.txt
@@ -35,7 +35,6 @@ set(sources
 
 # Build executable
 add_executable(${target}
-    MACOSX_BUNDLE
     ${headers}
     ${sources}
 )


### PR DESCRIPTION
Don't make `llassetgen-cmd` an app bundle: App bundles are for GUI apps not for command line tools.