### PR TITLE
fix windows deployment and dependencies

### DIFF
--- a/cmake/RuntimeDependencies.cmake
+++ b/cmake/RuntimeDependencies.cmake
@@ -28,12 +28,14 @@ if(OPTION_SELF_CONTAINED)
     find_file(DLLS_MSVCRT msvcrt.dll)
     find_file(DLLS_MSVCP114 msvcp140.dll) 
     find_file(DLLS_VCRUNTIME vcruntime140.dll)
+    find_file(DLLS_WIN qwindows.dll)
 
 
     set(OPTION_DEPLOY_DEBUG_DLLS FALSE CACHE BOOL "if set, debug versions of certain dlls will be packaged")
     if (OPTION_DEPLOY_DEBUG_DLLS)
         find_file(DLLS_MSVCP114D msvcp114d.dll)
         find_file(DLLS_MSVCR114D msvcr114d.dll)
+        find_file(DLLS_WIND qwindowsd.dll)
     else()
     endif()
 
@@ -53,6 +55,12 @@ if(OPTION_SELF_CONTAINED)
         ${DLLS_VCRUNTIME}
     )
 
+    set(PLATFORMS
+        ${DLLS_WIN}
+        ${DLLS_WIND}
+    )
+
     install(FILES ${DLLS} DESTINATION ${INSTALL_BIN} COMPONENT runtime)
+    install(FILES ${PLATFORMS} DESTINATION ${INSTALL_BIN}/platforms COMPONENT runtime)
 
 endif()

--- a/data/llassetgen-rendering/shader.frag
+++ b/data/llassetgen-rendering/shader.frag
@@ -42,9 +42,9 @@ float aastep1x3(float t, vec2 uv)
 {
     float y = dFdy(uv.y) * 1.0 / 3.0;
 
-    float v = tex(t, uv + vec2(0,-y))
-            + tex(t, uv + vec2(0, 0))
-            + tex(t, uv + vec2(0,+y));
+    float v = tex(t, uv + vec2(0.0,  -y))
+            + tex(t, uv + vec2(0.0, 0.0))
+            + tex(t, uv + vec2(0.0,  +y));
 
     return v / 3.0;
 }
@@ -70,7 +70,7 @@ float aastepQuincunx(float t, vec2 uv)
     float x = dFdx(uv.x) / 2.0;
     float y = dFdy(uv.y) / 2.0;
 
-    float v = tex(t, uv) * 4
+    float v = tex(t, uv) * 4.0
             + tex(t, uv + vec2(-x,+y))
             + tex(t, uv + vec2(-x,-y))
             + tex(t, uv + vec2(+x,+y))
@@ -126,17 +126,17 @@ float aastep3x3(float t, vec2 uv)
     float x = dFdx(uv.x) * 1.0 / 3.0;
     float y = dFdy(uv.y) * 1.0 / 3.0;
 
-    float v = tex(t, uv + vec2(-x,-y))
-            + tex(t, uv + vec2(-x, 0))
-            + tex(t, uv + vec2(-x,+y))
+    float v = tex(t, uv + vec2(-x,  -y))
+            + tex(t, uv + vec2(-x, 0.0))
+            + tex(t, uv + vec2(-x,  +y))
 
-            + tex(t, uv + vec2( 0,-y))
-            + tex(t, uv + vec2( 0, 0))
-            + tex(t, uv + vec2( 0,+y))
+            + tex(t, uv + vec2( 0.0,  -y))
+            + tex(t, uv + vec2( 0.0, 0.0))
+            + tex(t, uv + vec2( 0.0,  +y))
 
-            + tex(t, uv + vec2(+x,-y))
-            + tex(t, uv + vec2(+x, 0))
-            + tex(t, uv + vec2(+x,+y));
+            + tex(t, uv + vec2(+x,  -y))
+            + tex(t, uv + vec2(+x, 0.0))
+            + tex(t, uv + vec2(+x,  +y));
 
     return v / 9.0;
 }
@@ -175,7 +175,7 @@ float aastep4x4(float t, vec2 uv)
 
 void main()
 {
-    fragColor = vec4(1.0,0.0,0.0,1.0); //debugging color
+    fragColor = vec4(1.0, 0.0, 0.0, 1.0); //debugging color
 
     float s = texture(glyphs, v_uv).r;
     

--- a/data/llassetgen-rendering/shader.vert
+++ b/data/llassetgen-rendering/shader.vert
@@ -13,6 +13,6 @@ out vec2 v_uv;
 void main()
 {
     gl_Position = projection * modelView * vec4(corner * 2.0 - 1.0, -2.0, 1.0);
-    color = vec4(corner, 0.0, 1.0);
+    color = vec4(corner.x, corner.y, 0.0, 1.0);
     v_uv = texUV;
 }

--- a/llassetgen-config.cmake
+++ b/llassetgen-config.cmake
@@ -9,6 +9,7 @@
 set(MODULE_NAMES
     llassetgen
     llassetgen-cmd
+    llassetgen-rendering
 )
 
 

--- a/qt.conf
+++ b/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Plugins=plugins

--- a/source/llassetgen-rendering/WindowQt.cpp
+++ b/source/llassetgen-rendering/WindowQt.cpp
@@ -58,11 +58,9 @@ void WindowQt::exposeEvent(QExposeEvent* /*unused*/) { paint(); }
 void WindowQt::initialize() {
     makeCurrent();
 
-    initializeGL();
+    initialized = initializeGL();
 
     doneCurrent();
-
-    initialized = true;
 }
 
 void WindowQt::resize(QResizeEvent* event) {
@@ -150,7 +148,7 @@ void WindowQt::mouseReleaseEvent(QMouseEvent* /*event*/) {}
 
 void WindowQt::wheelEvent(QWheelEvent* /*event*/) {}
 
-void WindowQt::initializeGL() {}
+bool WindowQt::initializeGL() { return false; }
 
 void WindowQt::deinitializeGL() {}
 

--- a/source/llassetgen-rendering/WindowQt.h
+++ b/source/llassetgen-rendering/WindowQt.h
@@ -78,7 +78,7 @@ class WindowQt : public QWindow {
     void resize(QResizeEvent* event);
     void paint();
 
-    virtual void initializeGL();
+    virtual bool initializeGL();
     virtual void deinitializeGL();
     virtual void resizeGL(QResizeEvent* event);
     virtual void paintGL();

--- a/source/llassetgen-rendering/WindowQt.h
+++ b/source/llassetgen-rendering/WindowQt.h
@@ -83,5 +83,7 @@ class WindowQt : public QWindow {
     virtual void resizeGL(QResizeEvent* event);
     virtual void paintGL();
 
-    glbinding::ProcAddress getProcAddress(const char* name);
+   protected:
+    static WindowQt* s_getProcAddressHelper;
+    static glbinding::ProcAddress getProcAddress(const char* name);
 };

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -72,7 +72,7 @@ class Window : public WindowQt {
     virtual bool initializeGL() override {
         globjects::init([this](const char * name) {
             return getProcAddress(name);
-        }, globjects::Texture::BindlessImplementation::Legacy);
+        });
 
         std::cout << std::endl
                   << "OpenGL Version:  " << glbinding::aux::ContextInfo::version() << std::endl

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -70,9 +70,7 @@ class Window : public WindowQt {
     virtual ~Window() {}
 
     virtual bool initializeGL() override {
-        globjects::init([this](const char * name) {
-            return getProcAddress(name);
-        });
+        globjects::init(getProcAddress);
 
         std::cout << std::endl
                   << "OpenGL Version:  " << glbinding::aux::ContextInfo::version() << std::endl
@@ -334,7 +332,8 @@ class Window : public WindowQt {
     }
 
     virtual void resetTransform3D() override {
-        transform3D = glm::mat4(1.f);  // set identity        paint();
+        transform3D = glm::mat4(1.f);  // set identity
+        paint();
     }
 
     virtual void triggerNewDT() override {
@@ -408,7 +407,8 @@ class Window : public WindowQt {
     glm::vec4 backgroundColor = glm::vec4(1.f, 1.f, 1.f, 1.f);
     glm::vec4 fontColor = glm::vec4(0.f, 0.f, 0.f, 1.f);
     int samplerIndex = 0;
-    glm::mat4 transform3D = glm::mat4(1.f);    glm::mat4 projection = glm::perspective(45.f, 1.f, 0.0001f, 100.f);
+    glm::mat4 transform3D = glm::mat4(1.f);
+    glm::mat4 projection = glm::perspective(45.f, 1.f, 0.0001f, 100.f);
     unsigned int superSampling = 0;
     bool showDistanceField = false;
     float dtThreshold = 0.5;

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -69,10 +69,10 @@ class Window : public WindowQt {
 
     virtual ~Window() {}
 
-    virtual void initializeGL() override {
+    virtual bool initializeGL() override {
         globjects::init([this](const char * name) {
             return getProcAddress(name);
-        });
+        }, globjects::Texture::BindlessImplementation::Legacy);
 
         std::cout << std::endl
                   << "OpenGL Version:  " << glbinding::aux::ContextInfo::version() << std::endl
@@ -149,6 +149,8 @@ class Window : public WindowQt {
         program->setUniform("showDistanceField", showDistanceField);
         program->setUniform("superSampling", superSampling);
         program->setUniform("threshold", dtThreshold);
+
+        return true;
     }
 
     virtual void deinitializeGL() override {
@@ -195,7 +197,7 @@ class Window : public WindowQt {
         program->setUniform("showDistanceField", showDistanceField);
         program->setUniform("superSampling", superSampling);
         program->setUniform("threshold", dtThreshold);
-
+        vao->bind();
         vao->drawArrays(GL_TRIANGLE_STRIP, 0, 4);
         program->release();
 
@@ -333,7 +335,7 @@ class Window : public WindowQt {
     }
 
     virtual void resetTransform3D() override {
-        transform3D = glm::mat4();  // set identity
+        transform3D = glm::mat4(1.0);  // set identity
         paint();
     }
 
@@ -408,7 +410,7 @@ class Window : public WindowQt {
     glm::vec4 backgroundColor = glm::vec4(1.f, 1.f, 1.f, 1.f);
     glm::vec4 fontColor = glm::vec4(0.f, 0.f, 0.f, 1.f);
     int samplerIndex = 0;
-    glm::mat4 transform3D = glm::mat4();
+    glm::mat4 transform3D = glm::mat4(1.0);
     glm::mat4 projection = glm::perspective(45.f, 1.f, 0.0001f, 100.f);
     unsigned int superSampling = 0;
     bool showDistanceField = false;

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -334,7 +334,7 @@ class Window : public WindowQt {
     }
 
     virtual void resetTransform3D() override {
-        transform3D = glm::mat4(1.0);  // set identity
+        transform3D = glm::mat4(1.0f);  // set identity
         paint();
     }
 

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -197,7 +197,6 @@ class Window : public WindowQt {
         program->setUniform("showDistanceField", showDistanceField);
         program->setUniform("superSampling", superSampling);
         program->setUniform("threshold", dtThreshold);
-        vao->bind();
         vao->drawArrays(GL_TRIANGLE_STRIP, 0, 4);
         program->release();
 

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -409,7 +409,7 @@ class Window : public WindowQt {
     glm::vec4 backgroundColor = glm::vec4(1.f, 1.f, 1.f, 1.f);
     glm::vec4 fontColor = glm::vec4(0.f, 0.f, 0.f, 1.f);
     int samplerIndex = 0;
-    glm::mat4 transform3D = glm::mat4(1.0);
+    glm::mat4 transform3D = glm::mat4(1.0f);
     glm::mat4 projection = glm::perspective(45.f, 1.f, 0.0001f, 100.f);
     unsigned int superSampling = 0;
     bool showDistanceField = false;


### PR DESCRIPTION
fix: make qwindows.dll available via CMake variables
fix: newer GLM versions do not initialize matrix with identity
fix: handle Qt Spontaneous Events
fix: small adaptions in shader code and globjects::init, necessary for some drivers