### PR TITLE
include spacing characters into fnt-file, but don't render into png-f…

### DIFF
--- a/source/llassetgen-cmd/include/presets.h
+++ b/source/llassetgen-cmd/include/presets.h
@@ -3,9 +3,9 @@
 // If you want to add another preset, you have to adapt llassetgen-cmd::main::makeGlyphSet() to recognize the new preset
 // and its encoding.
 
-// all printable ascii characters, except for space
+// all printable ascii characters
 constexpr char ascii[] =
-    "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
 // a custom preset using unicode, that also contains characters that are potentially unrenderable by a lot of fontfaces.
 constexpr char16_t preset20180319[] = {

--- a/source/llassetgen-cmd/source/main.cpp
+++ b/source/llassetgen-cmd/source/main.cpp
@@ -158,12 +158,18 @@ int parseAtlasArgs(int argc, char** argv) {
 
         if (createFnt) {
             std::string faceName = static_cast<bool>(*fontNameOpt) ? fontName : "Unknown";
-            FntWriter writer{fontFinder.fontFace, faceName, fontSize, 1};
+            FntWriter writer{ fontFinder.fontFace, faceName, fontSize, 1 };
             writer.setAtlasProperties(p.atlasSize);
             writer.readFont(glyphSet.begin(), glyphSet.end());
-            auto gIt = glyphSet.begin();
-            for (auto rectIt = p.rects.begin(); rectIt < p.rects.end(); gIt++, rectIt++) {
-                writer.setCharInfo(static_cast<FT_ULong>(*gIt), *rectIt);
+
+            std::set<FT_ULong> charsWithoutRect = fontFinder.nonDepictableChars;
+            bool charIsDepictable = true;
+            auto rectIt = p.rects.begin();
+            for (auto gIt = glyphSet.begin(); gIt != glyphSet.end(); gIt++) {
+                charIsDepictable = writer.setCharInfo(static_cast<FT_ULong>(*gIt), *rectIt, charsWithoutRect);
+                if (charIsDepictable) {
+                    ++rectIt;
+                }
             }
             writer.saveFnt(fntPath);
         }

--- a/source/llassetgen/include/llassetgen/FntWriter.h
+++ b/source/llassetgen/include/llassetgen/FntWriter.h
@@ -76,6 +76,7 @@ namespace llassetgen {
         void setAtlasProperties(Vec2<PackingSizeType> size);
         void saveFnt(std::string filepath);
         void setCharInfo(FT_ULong charcode, Rect<PackingSizeType> charArea);
+        bool setCharInfo(FT_ULong charcode, Rect<PackingSizeType> charArea, std::set<FT_ULong> charsWithoutRect);
 
        private:
         void setFontInfo();

--- a/source/llassetgen/include/llassetgen/FontFinder.h
+++ b/source/llassetgen/include/llassetgen/FontFinder.h
@@ -22,7 +22,7 @@ namespace llassetgen {
 
         std::vector<Image> renderGlyphs(const std::set<unsigned long>& glyphs, int size, size_t padding = 0,
                                         size_t divisibleBy = 1);
-
+        std::set<FT_ULong> nonDepictableChars;
         FT_Face fontFace;
 
        private:

--- a/source/llassetgen/source/FntWriter.cpp
+++ b/source/llassetgen/source/FntWriter.cpp
@@ -65,6 +65,59 @@ namespace llassetgen {
         */
     }
 
+    /**
+     * The set charsWithoutRect contains the code points of the (valid) characters that could not be rendered by freetype.
+     * This is usually the case for spacing characters (e.g., space).
+     * Returns a bool, stating wether the charArea was used (true) or ignored (false). This makes it easier to use
+     * this function while iterating over charcodes and charAreas.
+     */
+    bool FntWriter::setCharInfo(FT_ULong charcode, Rect<PackingSizeType> charArea, std::set<FT_ULong> charsWithoutRect) {
+
+        size_t charAreaPosX;
+        size_t charAreaPosY;
+        size_t charAreaWidth;
+        size_t charAreaHeight;
+
+        const bool charIsDepictable = charsWithoutRect.find(charcode) == charsWithoutRect.end();
+        if (charIsDepictable) {
+            charAreaPosX = charArea.position.x;
+            charAreaPosY = charArea.position.y;
+            charAreaWidth = charArea.size.x;
+            charAreaHeight = charArea.size.y;
+        } else {
+            // for example, the space char, is not depictable (thus, is not contained in the glyph texture), but
+            // actually has a width in typesetting (called xAdvance).
+            // The position in the texture atlas (at the pixel's color at that position) has no meaning, has the
+            // width and height of that glyph in the texture is zero.
+            charAreaPosX = 0;
+            charAreaPosY = 0;
+            charAreaWidth = 0;
+            charAreaHeight = 0;
+        }
+
+        FT_UInt gindex = FT_Get_Char_Index(face, charcode);
+        FT_Load_Glyph(face, gindex, FT_LOAD_DEFAULT);
+
+        // bearing is provided in 26.6 fixed - point format
+        FT_Pos yBearing = float(face->glyph->metrics.horiBearingY) / 64.f;
+        maxYBearing = std::max(yBearing, maxYBearing);
+
+        CharInfo charInfo;
+        charInfo.id = charcode;
+        charInfo.x = charAreaPosX;
+        charInfo.y = charAreaPosY;
+        charInfo.width = charAreaWidth;
+        charInfo.height = charAreaHeight;
+        charInfo.xAdvance = float(face->glyph->linearHoriAdvance) / 65536.f;
+        charInfo.xOffset = float(face->glyph->metrics.horiBearingX) / 64.f;
+        charInfo.yOffset = yBearing;
+        charInfo.page = 1;
+        charInfo.chnl = 15;
+        charInfos.push_back(charInfo);
+
+        return charIsDepictable;
+    }
+
     void FntWriter::setCharInfo(FT_ULong charcode, Rect<PackingSizeType> charArea) {
         FT_UInt gindex = FT_Get_Char_Index(face, charcode);
         FT_Load_Glyph(face, gindex, FT_LOAD_DEFAULT);

--- a/source/llassetgen/source/FontFinder.cpp
+++ b/source/llassetgen/source/FontFinder.cpp
@@ -131,7 +131,6 @@ namespace llassetgen {
                 nonDepictableChars.insert(static_cast<FT_ULong>(glyph));
             } else {
                 Image img = {bitmap, padding, divisibleBy};
-                auto a = bitmap.buffer;
                 v.push_back(std::move(img));
             }
         }

--- a/source/llassetgen/source/FontFinder.cpp
+++ b/source/llassetgen/source/FontFinder.cpp
@@ -113,19 +113,27 @@ namespace llassetgen {
 
             FT_UInt charIndex = FT_Get_Char_Index(fontFace, static_cast<FT_ULong>(glyph));
             if (charIndex == 0) {
-                std::cerr << "Warning: Font does not contain glyph with code " << glyph << ". Omitted." << std::endl;
+                std::cerr << "Omitting glyph with code " << glyph << ", because the Font does not contain that glyph." << std::endl;
                 continue;
             }
 
             FT_Error err = FT_Load_Glyph(fontFace, charIndex, FT_LOAD_RENDER | FT_LOAD_TARGET_MONO);
-            FT_Bitmap& bitmap = fontFace->glyph->bitmap;
-            if (err || bitmap.buffer == nullptr) {
-                std::cerr << "Warning: Omitting glyph with code " + std::to_string(glyph) + " which could not be rendered." << std::endl;
+            if (err) {
+                std::cerr << "Omitting glyph with code  " << glyph << "because of Error : " << err << std::endl;
                 continue;
             }
 
-            Image img = { bitmap, padding, divisibleBy };
-            v.push_back(std::move(img));
+            FT_Bitmap& bitmap = fontFace->glyph->bitmap;
+            if (bitmap.buffer == nullptr) {
+                // standard behaviour for space char
+                std::cerr << "Note: Glyph with code " << glyph << " is not depictable, but will appear in the fnt-File."
+                          << std::endl;
+                nonDepictableChars.insert(static_cast<FT_ULong>(glyph));
+            } else {
+                Image img = {bitmap, padding, divisibleBy};
+                auto a = bitmap.buffer;
+                v.push_back(std::move(img));
+            }
         }
         return v;
     }

--- a/source/tests/llassetgen-tests/FntWriter.cpp
+++ b/source/tests/llassetgen-tests/FntWriter.cpp
@@ -26,7 +26,8 @@ TEST(FntWriterTest, createFntFile) {
 
 	unsigned int fontSize = 32;
 	float scalingFactor = 1.0f;
-	FntWriter writer = FntWriter(face, faceName, fontSize, scalingFactor);
+	float padding = 0;
+	FntWriter writer = FntWriter(face, faceName, fontSize, scalingFactor, padding);
 	
 	FT_UInt gIndex;
 	std::set<FT_ULong> charcodes;
@@ -78,7 +79,8 @@ TEST(FntWriterTest, fntScaling) {
 
 	unsigned int fontSize = 32;
 	float scalingFactor = 0.5f;
-	FntWriter writer = FntWriter(face, faceName, fontSize, scalingFactor);
+	float padding = 0;
+	FntWriter writer = FntWriter(face, faceName, fontSize, scalingFactor, padding);
 	
 	FT_UInt gIndex;
 	std::set<FT_ULong> charcodes;


### PR DESCRIPTION
This is a possible solution for issue #66 .

Valid, but non-depictable characters (such as _space_) had no preserved rectangle in the font atlas, since they are not renderable. The resulting font atlas was not usable for normal text.

The current solution is to ignore non-depictable characters for the font atlas (`.png`), but export them in the font file (`.fnt`) with zero-values for texture-related attributes (`position`, `width`, `height`).

The `position` [0,0] in the font atlas always exists, although its pixel might not have a value suitable for the non-depictable character. This is fine, considering that a non-depictable character should not be depicted anyway. The attributes `width `and `height` are zero, thus no valid rectangle can be read from the font atlas.
Nevertheless, the typesetting-attributes (`xadvance`, `xoffset`, `yoffset`) are valid to use those invisible glyphs in typesetting.


Functionality:
The FontFinder gathers all characters, for which Freetype could not render a bitmap although the character is supported by the Font, into the set `nonDepictableChars`.
The function `FontWriter::setCharInfo` was extended to receive such a set and to return whether the current character was found in that set.