### PR TITLE
Refine values include padding

### DIFF
--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -326,8 +326,14 @@ class Window : public WindowQt {
 
     virtual void packingSizeChanged(QString value) override {
         int ds = value.toInt();
-        std::cout << "change downsampling to " << ds << std::endl;
-        downSampling = ds;
+
+        if (ds > 0) {
+            downSampling = ds;
+            std::cout << "change downsampling to " << ds << std::endl;
+        }
+        else {
+            std::cout << "Did not change downsampling to " << ds << " (but secretly, I love divison by zero!)" << std::endl;
+        }
     }
 
     virtual void resetTransform3D() override {

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -445,10 +445,10 @@ class Window : public WindowQt {
             constexpr char ascii[] =
                 " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
             constexpr char test[] =
-                " \'ABV^g|";
+                " \'ABV^g|xMm";
             constexpr char a[] = "a";
 
-            const char* s = test; //ascii
+            const char* s = ascii;
 
             // a custom preset using unicode
             /*

--- a/source/llassetgen-rendering/main.cpp
+++ b/source/llassetgen-rendering/main.cpp
@@ -412,10 +412,10 @@ class Window : public WindowQt {
     bool showDistanceField = false;
     float dtThreshold = 0.5;
     int dtAlgorithm = 0;
-    int packingAlgorithm = 0;
+    int packingAlgorithm = 1;
     int downSampling = 2;
 #ifdef SYSTEM_WINDOWS
-    QString fontName = "Verdana";
+    QString fontName = "Open Sans";
 #elif defined(SYSTEM_DARWIN)
     QString fontName = "Verdana";
 #else
@@ -424,7 +424,7 @@ class Window : public WindowQt {
     unsigned int fontSize = 256;
     int drBlack = -50;
     int drWhite = 50;
-    int padding = 20;
+    int padding = 16;
 
     bool isPanning = false;
     bool isRotating = false;
@@ -444,9 +444,11 @@ class Window : public WindowQt {
             // all printable ascii characters
             constexpr char ascii[] =
                 " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+            constexpr char test[] =
+                " \'ABV^g|";
             constexpr char a[] = "a";
 
-            const char* s = ascii;
+            const char* s = test; //ascii
 
             // a custom preset using unicode
             /*
@@ -712,6 +714,7 @@ void setupGUI(QMainWindow* window) {
     // item order is important
     packComboBox->addItem("Shelf");
     packComboBox->addItem("Max Rects");
+    packComboBox->setCurrentIndex(1);
     QObject::connect(packComboBox, SIGNAL(currentIndexChanged(int)), glwindow, SLOT(packingAlgoChanged(int)));
     acLayout->addRow("Packing:", packComboBox);
 

--- a/source/llassetgen/source/FntWriter.cpp
+++ b/source/llassetgen/source/FntWriter.cpp
@@ -86,9 +86,9 @@ namespace llassetgen {
             charAreaWidth = charArea.size.x;
             charAreaHeight = charArea.size.y;
         } else {
-            // for example, the space char, is not depictable (thus, is not contained in the glyph texture), but
+            // for example, the space char is not depictable (thus, is not contained in the glyph texture), but
             // actually has a width in typesetting (called xAdvance).
-            // The position in the texture atlas (at the pixel's color at that position) has no meaning, has the
+            // The position in the texture atlas (at the pixel's color at that position) has no meaning, as the
             // width and height of that glyph in the texture is zero.
             charAreaPosX = 0;
             charAreaPosY = 0;
@@ -214,8 +214,8 @@ namespace llassetgen {
         fntFile << "common "
                 << "lineHeight=" << float(fontCommon.lineHeight) * scalingFactor << " "
                 << "base=" << float(fontCommon.base) * scalingFactor << " "
-                << "ascent=" << float(fontCommon.ascent) * scalingFactor << " "
-                << "descent=" << float(fontCommon.descent) * scalingFactor << " "
+                << "ascent=" << float(fontCommon.ascent + fontInfo.padding.up) * scalingFactor << " "
+                << "descent=" << float(fontCommon.descent + fontInfo.padding.up + fontInfo.padding.down) * scalingFactor << " "
                 << "scaleW=" << fontCommon.scaleW << " "
                 << "scaleH=" << fontCommon.scaleH << " "
                 << "pages=" << fontCommon.pages << " "
@@ -239,8 +239,8 @@ namespace llassetgen {
                     << "y=" << charInfo.y << " "
                     << "width=" << charInfo.width << " "
                     << "height=" << charInfo.height << " "
-                    << "xoffset=" << charInfo.xOffset * scalingFactor << " "
-                    << "yoffset=" << (fontCommon.ascent - charInfo.yOffset) * scalingFactor << " "
+                    << "xoffset=" << (charInfo.xOffset - fontInfo.padding.left) * scalingFactor << " "
+                    << "yoffset=" << (fontCommon.ascent - (charInfo.yOffset - fontInfo.padding.up)) * scalingFactor << " "
                     << "xadvance=" << float(charInfo.xAdvance) * scalingFactor << " "
                     << "page=" << charInfo.page << " "
                     << "chnl=" << int(charInfo.chnl) << std::endl;

--- a/source/llassetgen/source/FntWriter.cpp
+++ b/source/llassetgen/source/FntWriter.cpp
@@ -52,7 +52,7 @@ namespace llassetgen {
         fontCommon.base = float(face->size->metrics.ascender) / 64.f;
         fontCommon.descent = float(face->size->metrics.descender) / 64.f;
 
-        // havent found any of the following information
+        // haven't found any of the following information
         // irrelevant for distance fields --> ignore them
         /*
         fontInfo.stretchH = 1.0f;
@@ -214,8 +214,8 @@ namespace llassetgen {
         fntFile << "common "
                 << "lineHeight=" << float(fontCommon.lineHeight) * scalingFactor << " "
                 << "base=" << float(fontCommon.base) * scalingFactor << " "
-                << "ascent=" << float(fontCommon.ascent + fontInfo.padding.up) * scalingFactor << " "
-                << "descent=" << float(fontCommon.descent + fontInfo.padding.up + fontInfo.padding.down) * scalingFactor << " "
+                << "ascent=" << float(fontCommon.ascent) * scalingFactor << " "
+                << "descent=" << float(fontCommon.descent) * scalingFactor << " "
                 << "scaleW=" << fontCommon.scaleW << " "
                 << "scaleH=" << fontCommon.scaleH << " "
                 << "pages=" << fontCommon.pages << " "
@@ -239,8 +239,8 @@ namespace llassetgen {
                     << "y=" << charInfo.y << " "
                     << "width=" << charInfo.width << " "
                     << "height=" << charInfo.height << " "
-                    << "xoffset=" << (charInfo.xOffset - fontInfo.padding.left) * scalingFactor << " "
-                    << "yoffset=" << (fontCommon.ascent - (charInfo.yOffset - fontInfo.padding.up)) * scalingFactor << " "
+                    << "xoffset=" << (charInfo.xOffset) * scalingFactor << " "
+                    << "yoffset=" << (fontCommon.base - charInfo.yOffset) * scalingFactor << " "
                     << "xadvance=" << float(charInfo.xAdvance) * scalingFactor << " "
                     << "page=" << charInfo.page << " "
                     << "chnl=" << int(charInfo.chnl) << std::endl;

--- a/source/llassetgen/source/FntWriter.cpp
+++ b/source/llassetgen/source/FntWriter.cpp
@@ -239,7 +239,7 @@ namespace llassetgen {
                     << "y=" << charInfo.y << " "
                     << "width=" << charInfo.width << " "
                     << "height=" << charInfo.height << " "
-                    << "xoffset=" << (charInfo.xOffset) * scalingFactor << " "
+                    << "xoffset=" << charInfo.xOffset * scalingFactor << " "
                     << "yoffset=" << (fontCommon.base - charInfo.yOffset) * scalingFactor << " "
                     << "xadvance=" << float(charInfo.xAdvance) * scalingFactor << " "
                     << "page=" << charInfo.page << " "


### PR DESCRIPTION
In the beginning, we thought that we might need to include padding in the exported values for a correct typesetting result. But turns out we don't.

However, this PR provides two fixes:

1. Calculate `yoffset` based on `fontCommon.base` instead of `fontCommon.ascent`
2. Don't accept 0 as a valid downsampling factor